### PR TITLE
docs: document XDG fallback and auto-create dirs for cases.json

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -49,8 +49,9 @@ The server supports `resources/listChanged`. `resources/subscribe` registers int
 - Default location resolution for cases database (`cases.json`):
   1) If `MCP_RCA_CASES_PATH` is set, that absolute/relative path is used.
   2) Otherwise, if the repository-local `data/` directory exists, use `<repo>/data/cases.json` (dev-friendly default).
-  3) Otherwise, fall back to the user data directory following XDG base directory conventions:
-     - `"$XDG_DATA_HOME/mcp-rca/cases.json"` or, when undefined on Linux: `"~/.local/share/mcp-rca/cases.json"`.
+  3) Otherwise, fall back to the user data directory:
+    - Linux: `"$XDG_DATA_HOME/mcp-rca/cases.json"` or, when undefined: `"~/.local/share/mcp-rca/cases.json"`.
+    - Note: The current fallback primarily targets Linux/XDG. On macOS/Windows, set `MCP_RCA_CASES_PATH` explicitly to a desired absolute path.
 - Parent directories for the resolved path are created automatically on first write, avoiding `ENOENT` during atomic writes.
 - Recommended: set `MCP_RCA_CASES_PATH` to an absolute path in client configs to ensure multi-process consistency.
 - Each case has a `status` (`active` / `archived`). Toggle via the `case_update` tool.


### PR DESCRIPTION
This PR updates AGENT.md to document the data path resolution and durability improvements.\n\nHighlights:\n- Default cases.json path resolution order:\n  1) MCP_RCA_CASES_PATH when set\n  2) <repo>/data/cases.json when repo-local data/ exists (dev-friendly)\n  3) XDG user data dir: /mcp-rca/cases.json or ~/.local/share/mcp-rca/cases.json\n- Parent directories are created automatically to avoid ENOENT during atomic writes (.tmp).\n- Recommend setting MCP_RCA_CASES_PATH to an absolute path for multi-process consistency.\n\nNotes:\n- Related runtime fix for ENOENT and path fallback in caseStore.ts has already been implemented and tested (build + tests passing). This PR aligns the docs with the behavior.